### PR TITLE
Adding K8s settings and migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,15 @@ The following settings are optional and allow you to further configure your clus
 * `settings.kubernetes.standalone-mode`: Whether to run the kubelet in standalone mode, without connecting to an API server.  Defaults to `false`.
 * `settings.kubernetes.authentication-mode`: Which authentication method the kubelet should use to connect to the API server, and for incoming requests.  Defaults to `aws` for AWS variants, and `tls` for other variants.
 * `settings.kubernetes.bootstrap-token`: The token to use for [TLS bootstrapping](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/).  This is only used with the `tls` authentication mode, and is otherwise ignored.
+* `settings.kubernetes.eviction-hard`: The hard eviction Signal and Thresholds you set up to reclaim the associated starved resource.
+  Remember to quote keys (since they often contain ".") and to quote all values.
+  * Example user data for setting up eviction hard:
+    ```
+    [settings.kubernetes.eviction-hard]
+    "memory.available" = "15%"
+    "nodefs.inodesFree" = "15Mi"
+    "pid.available" = "15%"
+    ```
 
 You can also optionally specify static pods for your node with the following settings.
 Static pods can be particularly useful when running in standalone mode.

--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ The following settings are optional and allow you to further configure your clus
     memory = "1024Mi"
     ephemeral-storage = "1Gi"
     ```
+* `settings.kubernetes.cpu-manager-policy`: Specifies the CPU manager policy. Possible values are `static` and `none`. Defaults to `none`.
 
 You can also optionally specify static pods for your node with the following settings.
 Static pods can be particularly useful when running in standalone mode.

--- a/README.md
+++ b/README.md
@@ -327,6 +327,12 @@ The following settings are optional and allow you to further configure your clus
     ephemeral-storage = "1Gi"
     ```
 * `settings.kubernetes.cpu-manager-policy`: Specifies the CPU manager policy. Possible values are `static` and `none`. Defaults to `none`.
+* `settings.kubernetes.allowed-unsafe-sysctls`: Enables specified list of unsafe sysctls.
+  * Example user data for setting up allowed unsafe sysctls:
+    ```
+    allowed-unsafe-sysctls = ["net.core.somaxconn", "net.ipv4.ip_local_port_range"]
+    ```
+
 
 You can also optionally specify static pods for your node with the following settings.
 Static pods can be particularly useful when running in standalone mode.

--- a/README.md
+++ b/README.md
@@ -318,6 +318,14 @@ The following settings are optional and allow you to further configure your clus
     "nodefs.inodesFree" = "15Mi"
     "pid.available" = "15%"
     ```
+* `settings.kubernetes.kube-reserved`: Resources reserved for node components.
+  * Example user data for setting up kube reserved:
+    ```
+    [settings.kubernetes.kube-reserved]
+    cpu = "1"
+    memory = "1024Mi"
+    ephemeral-storage = "1Gi"
+    ```
 
 You can also optionally specify static pods for your node with the following settings.
 Static pods can be particularly useful when running in standalone mode.

--- a/Release.toml
+++ b/Release.toml
@@ -29,3 +29,7 @@ version = "1.0.6"
     "migrate_v1.0.6_add-shibaken.lz4",
     "migrate_v1.0.6_admin-container-v0-6-0.lz4",
 ]
+"(1.0.6, 1.1.0)" = [
+    "migrate_v1.1.0_kubelet-kube-reserved-and-eviction-hard.lz4",
+    "migrate_v1.1.0_kubelet-unsafe-sysctl-and-cpu-manager-policy.lz4",
+]

--- a/packages/kubernetes-1.15/kubelet-config
+++ b/packages/kubernetes-1.15/kubelet-config
@@ -29,6 +29,12 @@ authorization:
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
+{{~#if settings.kubernetes.eviction-hard}}
+evictionHard:
+  {{~#each settings.kubernetes.eviction-hard}}
+  {{@key}}: "{{this}}"
+  {{~/each}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.15/kubelet-config
+++ b/packages/kubernetes-1.15/kubelet-config
@@ -40,6 +40,9 @@ kubeReserved:
   {{@key}}: "{{this}}"
   {{~/each}}
 cpuManagerPolicy: {{settings.kubernetes.cpu-manager-policy}}
+{{~#if settings.kubernetes.allowed-unsafe-sysctls}}
+allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.15/kubelet-config
+++ b/packages/kubernetes-1.15/kubelet-config
@@ -39,6 +39,7 @@ kubeReserved:
   {{~#each settings.kubernetes.kube-reserved}}
   {{@key}}: "{{this}}"
   {{~/each}}
+cpuManagerPolicy: {{settings.kubernetes.cpu-manager-policy}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.15/kubelet-config
+++ b/packages/kubernetes-1.15/kubelet-config
@@ -35,6 +35,10 @@ evictionHard:
   {{@key}}: "{{this}}"
   {{~/each}}
 {{~/if}}
+kubeReserved:
+  {{~#each settings.kubernetes.kube-reserved}}
+  {{@key}}: "{{this}}"
+  {{~/each}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -29,6 +29,12 @@ authorization:
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
+{{~#if settings.kubernetes.eviction-hard}}
+evictionHard:
+  {{~#each settings.kubernetes.eviction-hard}}
+  {{@key}}: "{{this}}"
+  {{~/each}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -40,6 +40,9 @@ kubeReserved:
   {{@key}}: "{{this}}"
   {{~/each}}
 cpuManagerPolicy: {{settings.kubernetes.cpu-manager-policy}}
+{{~#if settings.kubernetes.allowed-unsafe-sysctls}}
+allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -39,6 +39,7 @@ kubeReserved:
   {{~#each settings.kubernetes.kube-reserved}}
   {{@key}}: "{{this}}"
   {{~/each}}
+cpuManagerPolicy: {{settings.kubernetes.cpu-manager-policy}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.16/kubelet-config
+++ b/packages/kubernetes-1.16/kubelet-config
@@ -35,6 +35,10 @@ evictionHard:
   {{@key}}: "{{this}}"
   {{~/each}}
 {{~/if}}
+kubeReserved:
+  {{~#each settings.kubernetes.kube-reserved}}
+  {{@key}}: "{{this}}"
+  {{~/each}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -29,6 +29,12 @@ authorization:
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
+{{~#if settings.kubernetes.eviction-hard}}
+evictionHard:
+  {{~#each settings.kubernetes.eviction-hard}}
+  {{@key}}: "{{this}}"
+  {{~/each}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -40,6 +40,9 @@ kubeReserved:
   {{@key}}: "{{this}}"
   {{~/each}}
 cpuManagerPolicy: {{settings.kubernetes.cpu-manager-policy}}
+{{~#if settings.kubernetes.allowed-unsafe-sysctls}}
+allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -39,6 +39,7 @@ kubeReserved:
   {{~#each settings.kubernetes.kube-reserved}}
   {{@key}}: "{{this}}"
   {{~/each}}
+cpuManagerPolicy: {{settings.kubernetes.cpu-manager-policy}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.17/kubelet-config
+++ b/packages/kubernetes-1.17/kubelet-config
@@ -35,6 +35,10 @@ evictionHard:
   {{@key}}: "{{this}}"
   {{~/each}}
 {{~/if}}
+kubeReserved:
+  {{~#each settings.kubernetes.kube-reserved}}
+  {{@key}}: "{{this}}"
+  {{~/each}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -29,6 +29,12 @@ authorization:
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
+{{~#if settings.kubernetes.eviction-hard}}
+evictionHard:
+  {{~#each settings.kubernetes.eviction-hard}}
+  {{@key}}: "{{this}}"
+  {{~/each}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -40,6 +40,9 @@ kubeReserved:
   {{@key}}: "{{this}}"
   {{~/each}}
 cpuManagerPolicy: {{settings.kubernetes.cpu-manager-policy}}
+{{~#if settings.kubernetes.allowed-unsafe-sysctls}}
+allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -39,6 +39,7 @@ kubeReserved:
   {{~#each settings.kubernetes.kube-reserved}}
   {{@key}}: "{{this}}"
   {{~/each}}
+cpuManagerPolicy: {{settings.kubernetes.cpu-manager-policy}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.18/kubelet-config
+++ b/packages/kubernetes-1.18/kubelet-config
@@ -35,6 +35,10 @@ evictionHard:
   {{@key}}: "{{this}}"
   {{~/each}}
 {{~/if}}
+kubeReserved:
+  {{~#each settings.kubernetes.kube-reserved}}
+  {{@key}}: "{{this}}"
+  {{~/each}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -29,6 +29,12 @@ authorization:
 clusterDomain: {{settings.kubernetes.cluster-domain}}
 clusterDNS:
 - {{settings.kubernetes.cluster-dns-ip}}
+{{~#if settings.kubernetes.eviction-hard}}
+evictionHard:
+  {{~#each settings.kubernetes.eviction-hard}}
+  {{@key}}: "{{this}}"
+  {{~/each}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -40,6 +40,9 @@ kubeReserved:
   {{@key}}: "{{this}}"
   {{~/each}}
 cpuManagerPolicy: {{settings.kubernetes.cpu-manager-policy}}
+{{~#if settings.kubernetes.allowed-unsafe-sysctls}}
+allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
+{{~/if}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -39,6 +39,7 @@ kubeReserved:
   {{~#each settings.kubernetes.kube-reserved}}
   {{@key}}: "{{this}}"
   {{~/each}}
+cpuManagerPolicy: {{settings.kubernetes.cpu-manager-policy}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/packages/kubernetes-1.19/kubelet-config
+++ b/packages/kubernetes-1.19/kubelet-config
@@ -35,6 +35,10 @@ evictionHard:
   {{@key}}: "{{this}}"
   {{~/each}}
 {{~/if}}
+kubeReserved:
+  {{~#each settings.kubernetes.kube-reserved}}
+  {{@key}}: "{{this}}"
+  {{~/each}}
 resolvConf: "/etc/resolv.conf"
 hairpinMode: hairpin-veth
 cgroupDriver: systemd

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1645,6 +1645,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubelet-kube-reserved-and-eviction-hard"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "kubelet-standalone-tls-services"
 version = "0.1.0"
 dependencies = [
@@ -1653,6 +1660,13 @@ dependencies = [
 
 [[package]]
 name = "kubelet-standalone-tls-settings"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "kubelet-unsafe-sysctl-and-cpu-manager-policy"
 version = "0.1.0"
 dependencies = [
  "migration-helpers",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2322,6 +2322,7 @@ version = "0.1.0"
 dependencies = [
  "cargo-readme",
  "lazy_static",
+ "num_cpus",
  "reqwest",
  "serde_json",
  "snafu",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -46,6 +46,8 @@ members = [
     "api/migration/migrations/v1.0.6/control-container-v0-4-2",
     "api/migration/migrations/v1.0.6/add-shibaken",
     "api/migration/migrations/v1.0.6/admin-container-v0-6-0",
+    "api/migration/migrations/v1.1.0/kubelet-kube-reserved-and-eviction-hard",
+    "api/migration/migrations/v1.1.0/kubelet-unsafe-sysctl-and-cpu-manager-policy",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.1.0/kubelet-kube-reserved-and-eviction-hard/Cargo.toml
+++ b/sources/api/migration/migrations/v1.1.0/kubelet-kube-reserved-and-eviction-hard/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kubelet-kube-reserved-and-eviction-hard"
+version = "0.1.0"
+authors = ["Tianhao Geng <tianhg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.1.0/kubelet-kube-reserved-and-eviction-hard/src/main.rs
+++ b/sources/api/migration/migrations/v1.1.0/kubelet-kube-reserved-and-eviction-hard/src/main.rs
@@ -1,0 +1,25 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added two new settings for configuring kubelet, `kubernetes.kube-reserved`
+/// and `settings.kubernetes.eviction-hard`.  We don't want to track all possible
+/// keys for these settings, so we remove the whole prefix when we downgrade.
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.kubernetes.kube-reserved",
+        "settings.kubernetes.eviction-hard",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.1.0/kubelet-unsafe-sysctl-and-cpu-manager-policy/Cargo.toml
+++ b/sources/api/migration/migrations/v1.1.0/kubelet-unsafe-sysctl-and-cpu-manager-policy/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kubelet-unsafe-sysctl-and-cpu-manager-policy"
+version = "0.1.0"
+authors = ["Tianhao Geng <tianhg@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.1.0/kubelet-unsafe-sysctl-and-cpu-manager-policy/src/main.rs
+++ b/sources/api/migration/migrations/v1.1.0/kubelet-unsafe-sysctl-and-cpu-manager-policy/src/main.rs
@@ -1,0 +1,24 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+///We added two new settings for configuring kubelet, `kubernetes.allowed-unsafe-sysctls`
+/// and  "settings.kubernetes.cpu-manager-policy".
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.kubernetes.allowed-unsafe-sysctls",
+        "settings.kubernetes.cpu-manager-policy",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/pluto/Cargo.toml
+++ b/sources/api/pluto/Cargo.toml
@@ -14,6 +14,7 @@ lazy_static = "1.4"
 reqwest = { version = "0.10", default-features = false, features = ["blocking"]}
 serde_json = "1"
 snafu = "0.6"
+num_cpus = "1.0"
 
 [build-dependencies]
 cargo-readme = "3.1"

--- a/sources/models/src/aws-k8s-1.15/defaults.d/50-aws-k8s.toml
+++ b/sources/models/src/aws-k8s-1.15/defaults.d/50-aws-k8s.toml
@@ -50,6 +50,11 @@ cluster-dns-ip.setting-generator = "pluto cluster-dns-ip"
 node-ip.setting-generator = "pluto node-ip"
 affected-services = ["kubernetes"]
 
+[metadata.settings.kubernetes.kube-reserved]
+cpu.setting-generator = "pluto cpu-reserved"
+memory.setting-generator = "pluto memory-reserved"
+affected-services = ["kubernetes"]
+
 [metadata.settings.kubernetes.pod-infra-container-image]
 setting-generator = "pluto pod-infra-container-image"
 affected-services = ["kubernetes", "containerd"]
@@ -58,6 +63,7 @@ affected-services = ["kubernetes", "containerd"]
 cluster-domain = "cluster.local"
 standalone-mode = false
 authentication-mode = "aws"
+kube-reserved.ephemeral-storage = "1Gi"
 
 # Metrics
 [settings.metrics]

--- a/sources/models/src/aws-k8s-1.15/defaults.d/50-aws-k8s.toml
+++ b/sources/models/src/aws-k8s-1.15/defaults.d/50-aws-k8s.toml
@@ -64,6 +64,7 @@ cluster-domain = "cluster.local"
 standalone-mode = false
 authentication-mode = "aws"
 kube-reserved.ephemeral-storage = "1Gi"
+cpu-manager-policy = "none"
 
 # Metrics
 [settings.metrics]

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -101,7 +101,7 @@ use crate::modeled_types::{
     DNSDomain, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue, FriendlyVersion, Identifier,
     KubernetesAuthenticationMode, KubernetesBootstrapToken, KubernetesClusterName,
     KubernetesLabelKey, KubernetesLabelValue, KubernetesTaintValue,
-    Lockdown, SingleLineString, SysctlKey, Url, ValidBase64, EvictionHardKey,
+    Lockdown, SingleLineString, SysctlKey, Url, ValidBase64, EvictionHardKey, ReservedResourcesKey,
 };
 
 // Kubernetes static pod manifest settings
@@ -130,6 +130,7 @@ struct KubernetesSettings {
     // Note: Kubelet won't launch if you specify an effect it doesn't know about, but we don't want to
     // gatekeep all possible values, so we validate if eviction-hard and kube-reserved values are SingleLineString.
     eviction_hard: HashMap<EvictionHardKey, SingleLineString>,
+    kube_reserved: HashMap<ReservedResourcesKey, SingleLineString>,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -102,6 +102,7 @@ use crate::modeled_types::{
     KubernetesAuthenticationMode, KubernetesBootstrapToken, KubernetesClusterName,
     KubernetesLabelKey, KubernetesLabelValue, KubernetesTaintValue,
     Lockdown, SingleLineString, SysctlKey, Url, ValidBase64, EvictionHardKey, ReservedResourcesKey,
+    CpuManagerPolicy
 };
 
 // Kubernetes static pod manifest settings
@@ -131,6 +132,7 @@ struct KubernetesSettings {
     // gatekeep all possible values, so we validate if eviction-hard and kube-reserved values are SingleLineString.
     eviction_hard: HashMap<EvictionHardKey, SingleLineString>,
     kube_reserved: HashMap<ReservedResourcesKey, SingleLineString>,
+    cpu_manager_policy: CpuManagerPolicy,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -101,7 +101,7 @@ use crate::modeled_types::{
     DNSDomain, ECSAgentLogLevel, ECSAttributeKey, ECSAttributeValue, FriendlyVersion, Identifier,
     KubernetesAuthenticationMode, KubernetesBootstrapToken, KubernetesClusterName,
     KubernetesLabelKey, KubernetesLabelValue, KubernetesTaintValue,
-    Lockdown, SingleLineString, SysctlKey, Url, ValidBase64,
+    Lockdown, SingleLineString, SysctlKey, Url, ValidBase64, EvictionHardKey,
 };
 
 // Kubernetes static pod manifest settings
@@ -127,6 +127,9 @@ struct KubernetesSettings {
     authentication_mode: KubernetesAuthenticationMode,
     bootstrap_token: KubernetesBootstrapToken,
     standalone_mode: bool,
+    // Note: Kubelet won't launch if you specify an effect it doesn't know about, but we don't want to
+    // gatekeep all possible values, so we validate if eviction-hard and kube-reserved values are SingleLineString.
+    eviction_hard: HashMap<EvictionHardKey, SingleLineString>,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -133,6 +133,7 @@ struct KubernetesSettings {
     eviction_hard: HashMap<EvictionHardKey, SingleLineString>,
     kube_reserved: HashMap<ReservedResourcesKey, SingleLineString>,
     cpu_manager_policy: CpuManagerPolicy,
+    allowed_unsafe_sysctls: Vec<SingleLineString>,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.

--- a/sources/models/src/modeled_types/kubernetes.rs
+++ b/sources/models/src/modeled_types/kubernetes.rs
@@ -560,3 +560,52 @@ mod test_reserved_resources_key {
         }
     }
 }
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+/// CpuManagerPolicy represents a string that contains a valid cpu management policy. Default: None
+/// https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct CpuManagerPolicy {
+    inner: String,
+}
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum ValidCpuManagerPolicy {
+    Static,
+    None,
+}
+
+impl TryFrom<&str> for CpuManagerPolicy {
+    type Error = error::Error;
+
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        serde_plain::from_str::<ValidCpuManagerPolicy>(&input).context(
+            error::InvalideCpuManagerPolicy { input })?;
+        Ok(CpuManagerPolicy {
+            inner: input.to_string(),
+        })
+    }
+}
+string_impls_for!(CpuManagerPolicy, "CpuManagerPolicy");
+
+#[cfg(test)]
+mod test_cpu_manager_policy {
+    use super::CpuManagerPolicy;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn good_cpu_manager_policy() {
+        for ok in &["static", "none"] {
+            CpuManagerPolicy::try_from(*ok).unwrap();
+        }
+    }
+
+    #[test]
+    fn bad_cpu_manager_policy() {
+        for err in &["", "bad", "100", &"a".repeat(64)] {
+            CpuManagerPolicy::try_from(*err).unwrap_err();
+        }
+    }
+}

--- a/sources/models/src/modeled_types/mod.rs
+++ b/sources/models/src/modeled_types/mod.rs
@@ -62,6 +62,12 @@ pub mod error {
             field: String,
             source: serde_plain::Error,
         },
+
+        #[snafu(display("Invalid Cpu Manager policy '{}'", input))]
+        InvalideCpuManagerPolicy {
+            input: String,
+            source: serde_plain::Error,
+        },
     }
 }
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

### **Description of changes:**

- **Add new settings `eviction-hard`, `kube-reserved`, `cpu-manager-policy`, `allowed-unsafe-sysctls` to k8s. User can specify this setting in userdata.*

- Add migration for those settings


**example**: 

```
[settings.kubernetes.eviction-hard]
"memory.available" = "10Gi"
"nodefs.inodesFree" = “15%”
[settings.kubernetes.kube-reserved]
cpu = "70Mi"
memory = "1Gi"
ephemeral-storage = "1Gi"
[settings.kubernetes]
cpu-manager-poliocy = "static"
allowed-unsafe-sysctls = ["net.core.somaxconn", ...]
```

### **Testing done:**

- Build aws-eks-* images and launched instance.
- Migration test: tested the migration via upgrade and downgrade testing

### Eviction-hard test
***Test step1***:
Go to control container run `apiclient -u /settings` to check if expected setting is there.
`eviction-hard":{"memory.available":"99.999%"} `

***Test step2***:
ssh to admin contianer and look `etc/kubernetes/kubelet/config` to check if expected config is there.
```
evictionHard:
  memory.available: 15%
```
***Test step3*** - test effected/behavior:
set up eviction threshold to a high value for triggering eviction.
```
[evictionHard.memory]
"memory.available" = "99.99%" (high percentage to trigger eviction)
```
a) Go to EKS to check node condition 

MemoryPressure | True | kubelet has insufficient memory available
-- | -- | --

b) In admin contianer, check kubelet log by `journalctl -u kubelet`
```
eviction_manager.go:335] eviction manager: attempting to reclaim memory
eviction_manager.go:346] eviction manager: must evict pod(s) to reclaim memory
```
### kube-reservd test
_NodeAllocatable = NodeCapacity - Kube-reserved - system-reserved - eviction-threshold_
**cpu**
[settings.kubernetes.kube-reserved.cpu]
cpu = 1
Allocatable cpu = 2 - 1 = 1
	
```
EKS Resource allocation:
Name Capacity Allocatable
CPU		2		1
```

**memory**
[settings.kubernetes.kube-reserved.Memory]
memory = 1Gi

```
EKS Resource allocation:
Name    Capacity    Allocatable
Memory	7844780Ki	6693804Ki
```

**ephemeral-storage**
[settings.kubernetes.kube-reserved.ephemeral-storage]
ephemeral-storage = 1Gi

```
Capacity:
  attachable-volumes-aws-ebs:  25
  cpu:                         2
  ephemeral-storage:           20624592Ki
  hugepages-1Gi:               0
  hugepages-2Mi:               0
  memory:                      7930796Ki
  pods:                        29
Allocatable:
  attachable-volumes-aws-ebs:  25
  cpu:                         1
  ephemeral-storage:           19007623956
  hugepages-1Gi:               0
  hugepages-2Mi:               0
  memory:                      7828396Ki
  pods:                        29˜
```
### cpu-manager-policy test
```
bash-5.0# cat /var/lib/kubelet/cpu_manager_state
{"policyName":"static","defaultCpuSet":"0-1","checksum":3945352861}bash-5.0#
```
```
journalctl -u kubelet
cpu_manager.go:173] [cpumanager] starting with static policy
```
### allowed-unsafe-sysctls test
```
cat eks/kubernetes/kubelet/config

allowed-unsafe-sysctls = ["net.core.somaxconn", ]
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
